### PR TITLE
LABX-197 add job data provider dao

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,17 @@ docs/**
 *.svg
 git
 static/**
+
+stories/*
+pages/**
+*.js
+src/**/*.js
+
+!src/content/lib/CreateJobContent/validate.js
+!src/daos/index.js
+!src/daos/lib/ContractsManagerDAO.js
+!src/daos/lib/JobControllerDAO.js
+!src/daos/lib/JobsDataProviderDAO.js
+!src/models/app/JobModel.js
+!src/store/daos/actions.js
+!src/store/jobs/actions.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
     - node_modules
 
 script:
-  - npm test -- --coverage
+  - npm run lint
   #- npm run build
 
 after_script:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ""
   ],
   "dependencies": {
-    "@laborx/sc-abi": "^0.0.6",
+    "@laborx/sc-abi": "^0.0.7",
     "accounting": "^0.4.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "bignumber.js": "^6.0.0",
@@ -86,5 +86,6 @@
     "docker:upgrade": "yarn docker:build && yarn docker:restart",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
-  }
+  },
+  "pre-commit": [ "lint" ]
 }

--- a/src/content/lib/CreateJobContent/validate.js
+++ b/src/content/lib/CreateJobContent/validate.js
@@ -11,6 +11,7 @@ export default (values) => {
     tags: notEmpty(values.tags),
     legal: notEmpty(values.legal),
     board: notEmpty(values.board),
+    skills: notEmpty(values.skills),
     // conclusion: required(values.conclusion),
   }
 }

--- a/src/daos/index.js
+++ b/src/daos/index.js
@@ -5,6 +5,7 @@ import ERC20_LIBRARY_ABI from '@laborx/sc-abi/build/contracts/ERC20Library.json'
 import ERC20_INTERFACE_ABI from '@laborx/sc-abi/build/contracts/ERC20Interface.json'
 import MULTI_EVENTS_HISTORY_ABI from '@laborx/sc-abi/build/contracts/MultiEventsHistory.json'
 import JOB_CONTROLLER_ABI from '@laborx/sc-abi/build/contracts/JobController.json'
+import JOBS_DATA_PROVIDER_ABI from '@laborx/sc-abi/build/contracts/JobsDataProvider.json'
 import BOARD_CONTROLLER_ABI from '@laborx/sc-abi/build/contracts/BoardController.json'
 
 import ContractsManagerDAO from './lib/ContractsManagerDAO'
@@ -12,6 +13,7 @@ import ERC20LibraryDAO from './lib/ERC20LibraryDAO'
 import JobControllerDAO from './lib/JobControllerDAO'
 import BoardControllerDAO from './lib/BoardControllerDAO'
 import ERC20TokenDAO from './lib/ERC20TokenDAO'
+import JobsDataProviderDAO from "./lib/JobsDataProviderDAO"
 
 export { default as ethDAO } from './lib/ETHDAO'
 export { default as AbstractContractDAO } from './lib/AbstractContractDAO'
@@ -20,6 +22,7 @@ export { default as AbstractTokenDAO } from './lib/AbstractTokenDAO'
 export { default as ETHTokenDAO } from './lib/ETHTokenDAO'
 export { default as ContractsManagerDAO } from './lib/ContractsManagerDAO'
 export { default as JobControllerDAO } from './lib/JobControllerDAO'
+export { default as JobsDataProviderDAO } from './lib/JobsDataProviderDAO'
 export { default as BoardControllerDAO } from './lib/BoardControllerDAO'
 export { default as ERC20LibraryDAO } from './lib/ERC20LibraryDAO'
 
@@ -40,6 +43,12 @@ export const JOB_CONTROLLER = new ContractModel({
   type: "JobController",
   abi: JOB_CONTROLLER_ABI,
   DAOClass: JobControllerDAO,
+})
+
+export const JOBS_DATA_PROVIDER = new ContractModel({
+  type: "JobsDataProvider",
+  abi: JOBS_DATA_PROVIDER_ABI,
+  DAOClass: JobsDataProviderDAO,
 })
 
 export const BOARD_CONTROLLER = new ContractModel({

--- a/src/daos/lib/ContractsManagerDAO.js
+++ b/src/daos/lib/ContractsManagerDAO.js
@@ -12,7 +12,7 @@ export default class ContractsManagerDAO extends EventEmitter {
       this.disconnect()
     }
     // eslint-disable-next-line no-console
-    console.log('[ContractsManagerDAO] Connect')
+    console.log('[ContractsManagerDAO] Connect', this.abi.abi, this.address)
     this.contract = new web3.eth.Contract(this.abi.abi, this.address, options)
     this.web3 = web3
   }

--- a/src/models/app/JobModel.js
+++ b/src/models/app/JobModel.js
@@ -20,6 +20,10 @@ export const schemaFactory = () => ({
   skills: PropTypes.arrayOf(
     PropTypes.instanceOf(SkillModel)
   ),
+  paused: PropTypes.bool,
+  defaultPay: PropTypes.number,
+  pausedAt: PropTypes.number,
+  pausedFor: PropTypes.number,
 })
 
 export default class JobModel extends AbstractModel {

--- a/src/store/daos/actions.js
+++ b/src/store/daos/actions.js
@@ -5,6 +5,7 @@ import {
   ERC20_LIBRARY,
   JOB_CONTROLLER,
   BOARD_CONTROLLER,
+  JOBS_DATA_PROVIDER,
 } from 'src/daos'
 
 export const DAOS_REGISTER = 'daos/register'
@@ -28,6 +29,7 @@ export const initDAOs = ({ web3 }) => async (dispatch) => {
     ERC20_LIBRARY,
     JOB_CONTROLLER,
     BOARD_CONTROLLER,
+    JOBS_DATA_PROVIDER,
   ]
 
   const models = await Promise.all(

--- a/src/store/jobs/actions.js
+++ b/src/store/jobs/actions.js
@@ -20,14 +20,14 @@ export const initJobs = () => async (dispatch, getState) => {
 
 export const reloadJobs = () => async (dispatch, getState) => {
   const state = getState()
-  const jobControllerDAO = daoByType('JobController')(state)
+  const jobsDataProviderDAO = daoByType('JobsDataProvider')(state)
   const boardControlerDAO = daoByType('BoardController')(state)
   const signer = signerSelector()(state)
   dispatch({
     type: JOBS_CLEAR,
   })
   if (signer) {
-    const jobs = await jobControllerDAO.getJobs(boardControlerDAO, signer.address)
+    const jobs = await jobsDataProviderDAO.getJobs(boardControlerDAO, signer.address)
     dispatch({ type: JOBS_SAVE, jobs })
   }
 }
@@ -36,9 +36,9 @@ export const handleJobPosted = (e: JobPostedEvent) => async (dispatch, getState)
   // eslint-disable-next-line no-console
   console.log('jobs/handleJobPosted', e)
   const state = getState()
-  const jobControllerDAO = daoByType('JobController')(state)
+  const jobsDataProviderDAO = daoByType('JobsDataProvider')(state)
   const boardControlerDAO = daoByType('BoardController')(state)
-  const job = await jobControllerDAO.getJobById(boardControlerDAO, e.jobId)
+  const job = await jobsDataProviderDAO.getJobById(boardControlerDAO, e.jobId)
   dispatch({
     type: JOBS_SAVE,
     jobs: [ job ],
@@ -64,9 +64,11 @@ export const createJob = (form: JobFormModel) => async (dispatch, getState) => {
 
   const tx = jobControllerDAO.createPostJobTx(
     signer.address,
+    1, // flowType enum { TM = 1, FIXED_PRICE = 2 }
     form.area.code,
     form.category.code,
     SkillModel.writeArrayToMask(form.skills),
+    0, // defaultPay todo check what this parameter is for and mark up field on create job form
     detailsIPFSHash
   )
   await dispatch(executeTransaction({ tx, web3 }))


### PR DESCRIPTION
add eslint validation on pre commit hook + add job data provider dao and fix get jobs by ids usage

- eslint pre commit hook added. in eslintignore we ignore all files except files which we touched in commit. by this method we can fix 300+ current lint issues gradually

- in new version of sc 0.0.7 JobController has been splitted into JobController, JobCore, JobDataProvider contracts. getter methods goes to JobsDataProvider. according to this update we fix usage of getter methods. in addition, new version exposes new job props in JobsDataProvider#getJobByIds method, such as paused, pausedFor, pausedAt, defaultPay

